### PR TITLE
Fix findliburing

### DIFF
--- a/cmake/modules/Finduring.cmake
+++ b/cmake/modules/Finduring.cmake
@@ -7,7 +7,7 @@
 find_path(uring_INCLUDE_DIR
   NAMES liburing.h)
 find_library(uring_LIBRARIES
-  NAMES liburing.a liburing)
+  NAMES uring)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(uring


### PR DESCRIPTION
`find_package(... NAMES lib*)` is basically always wrong. The previous code was just hardcoding the static library path to work around the fact that this doesn't work. This breaks the build when only dynamic liburing builds are available.

Necessary for https://github.com/girlbossceo/conduwuit/pull/400